### PR TITLE
[feat] implement lubee-code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'com.google.code.gson:gson:2.8.7'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/Lubee/Lubee/calendar/domain/Calendar.java
+++ b/src/main/java/com/Lubee/Lubee/calendar/domain/Calendar.java
@@ -3,7 +3,6 @@ package com.Lubee.Lubee.calendar.domain;
 import com.Lubee.Lubee.calendar_memory.domain.CalendarMemory;
 import com.Lubee.Lubee.common.BaseEntity;
 import com.Lubee.Lubee.couple.domain.Couple;
-import com.Lubee.Lubee.memory.domain.Memory;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/Lubee/Lubee/calendar/domain/Calendar.java
+++ b/src/main/java/com/Lubee/Lubee/calendar/domain/Calendar.java
@@ -3,11 +3,13 @@ package com.Lubee.Lubee.calendar.domain;
 import com.Lubee.Lubee.calendar_memory.domain.CalendarMemory;
 import com.Lubee.Lubee.common.BaseEntity;
 import com.Lubee.Lubee.couple.domain.Couple;
+import com.Lubee.Lubee.date_comment.domain.DateComment;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -33,5 +35,7 @@ public class Calendar extends BaseEntity {
     @OneToMany(mappedBy = "calendar")
     private List<CalendarMemory> calendarMemories;
 
+    @OneToMany(mappedBy = "calendar", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DateComment> dateComments = new ArrayList<>();
 
 }

--- a/src/main/java/com/Lubee/Lubee/calendar_memory/domain/CalendarMemory.java
+++ b/src/main/java/com/Lubee/Lubee/calendar_memory/domain/CalendarMemory.java
@@ -30,4 +30,5 @@ public class CalendarMemory extends BaseEntity {
     @JoinColumn(name = "memory_id", nullable = false)
     private Memory memory;
 
+    
 }

--- a/src/main/java/com/Lubee/Lubee/common/config/RedisConfig.java
+++ b/src/main/java/com/Lubee/Lubee/common/config/RedisConfig.java
@@ -1,0 +1,44 @@
+package com.Lubee.Lubee.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Long> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Long> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericToStringSerializer<>(Long.class));
+        return template;
+    }
+
+    @Bean
+    public RedisTemplate<Long, String> reverseRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<Long, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new GenericToStringSerializer<>(Long.class));
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+
+}

--- a/src/main/java/com/Lubee/Lubee/common/enumSet/ErrorType.java
+++ b/src/main/java/com/Lubee/Lubee/common/enumSet/ErrorType.java
@@ -13,7 +13,10 @@ public enum ErrorType {
     NOT_FOUND(400,"해당 데이터가 존재하지 않습니다" ),
     LOGIN_FAIL(400, "로그인에 실패하였습니다. 아이디 OR 비밀번호를 확인해주세요"),
     REFRESH_TOKEN_NOT_VALIDATE(404, "Refresh 토큰이 존재하지 않거나 만료되었습니다."),
-    ACCESS_TOKEN_NOT_EXPIRED(400, "엑세스 토큰이 존재하지 않거나 만료되었습니다.")
+    ACCESS_TOKEN_NOT_EXPIRED(400, "엑세스 토큰이 존재하지 않거나 만료되었습니다."),
+    LUBEE_CODE_NOT_FOUND(400, "Lubee code가 존재하지 않거나 만료되었습니다."),
+    REQUESTER_ALREADY_COUPLED(400, "커플 신청자가 이미 커플입니다."),
+    RECEIVER_ALREADY_COUPLED(400, "커플 요청받은 사람이 이미 커플입니다."),
     ;
 
 

--- a/src/main/java/com/Lubee/Lubee/common/jwt/JwtUtil.java
+++ b/src/main/java/com/Lubee/Lubee/common/jwt/JwtUtil.java
@@ -2,7 +2,8 @@ package com.Lubee.Lubee.common.jwt;
 
 import com.Lubee.Lubee.common.enumSet.UserRoleEnum;
 import com.Lubee.Lubee.common.security.UserDetailsServiceImpl;
-import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/Lubee/Lubee/common/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/Lubee/Lubee/common/security/UserDetailsServiceImpl.java
@@ -1,6 +1,7 @@
 package com.Lubee.Lubee.common.security;
 
 import com.Lubee.Lubee.common.enumSet.ErrorType;
+import com.Lubee.Lubee.user.domain.User;
 import com.Lubee.Lubee.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;

--- a/src/main/java/com/Lubee/Lubee/couple/controller/CoupleController.java
+++ b/src/main/java/com/Lubee/Lubee/couple/controller/CoupleController.java
@@ -1,0 +1,38 @@
+package com.Lubee.Lubee.couple.controller;
+
+import com.Lubee.Lubee.common.api.ApiResponseDto;
+import com.Lubee.Lubee.couple.dto.LubeeCodeResponse;
+import com.Lubee.Lubee.couple.service.CoupleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/couples")
+public class CoupleController {
+
+    private final CoupleService coupleService;
+
+    @PostMapping("/lubee-code")
+    public ApiResponseDto<LubeeCodeResponse> generateLubeeCode(@AuthenticationPrincipal UserDetails userDetails){
+
+        return coupleService.generateLubeeCode(userDetails);
+    }
+
+    @GetMapping("/lubee-code/{id}")
+    public ApiResponseDto<LubeeCodeResponse> getLubeeCode(@PathVariable Long id){
+
+        return coupleService.findLubeeCode(id);
+    }
+
+    @PostMapping("/link")
+    public ApiResponseDto<Long> linkCouple(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam String inputCode) {
+
+        return coupleService.linkCouple(userDetails, inputCode);
+    }
+
+}

--- a/src/main/java/com/Lubee/Lubee/couple/domain/Couple.java
+++ b/src/main/java/com/Lubee/Lubee/couple/domain/Couple.java
@@ -6,9 +6,11 @@ import com.Lubee.Lubee.date_comment.domain.DateComment;
 import com.Lubee.Lubee.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -32,7 +34,7 @@ public class Couple {
 
     @OneToMany
     @JoinColumn(name = "user_id", nullable = false)
-    private List<User> user;
+    private List<User> user = new ArrayList<>();
 
     @OneToMany(mappedBy = "couple")
     private List<Calendar> calendars;
@@ -42,4 +44,14 @@ public class Couple {
 
     @OneToMany(mappedBy = "couple")
     private List<Anniversary> anniversaries;
+
+    @Builder
+    public Couple(User requester, User receiver) {
+        user.add(requester);
+        user.add(receiver);
+        this.subscribe = false;
+        this.total_honey = 0L;
+        this.present_honey = 0;
+    }
+
 }

--- a/src/main/java/com/Lubee/Lubee/couple/dto/LubeeCodeResponse.java
+++ b/src/main/java/com/Lubee/Lubee/couple/dto/LubeeCodeResponse.java
@@ -1,0 +1,18 @@
+package com.Lubee.Lubee.couple.dto;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class LubeeCodeResponse {
+
+    private String code;
+
+    public static LubeeCodeResponse of(String code) {
+
+        return new LubeeCodeResponse(code);
+    }
+
+}

--- a/src/main/java/com/Lubee/Lubee/couple/repository/CoupleRepository.java
+++ b/src/main/java/com/Lubee/Lubee/couple/repository/CoupleRepository.java
@@ -1,0 +1,8 @@
+package com.Lubee.Lubee.couple.repository;
+
+import com.Lubee.Lubee.couple.domain.Couple;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CoupleRepository extends JpaRepository<Couple, Long> {
+
+}

--- a/src/main/java/com/Lubee/Lubee/couple/service/CoupleService.java
+++ b/src/main/java/com/Lubee/Lubee/couple/service/CoupleService.java
@@ -1,0 +1,111 @@
+package com.Lubee.Lubee.couple.service;
+
+import com.Lubee.Lubee.common.api.ApiResponseDto;
+import com.Lubee.Lubee.common.api.ErrorResponse;
+import com.Lubee.Lubee.common.api.ResponseUtils;
+import com.Lubee.Lubee.common.enumSet.ErrorType;
+import com.Lubee.Lubee.common.exception.RestApiException;
+import com.Lubee.Lubee.couple.domain.Couple;
+import com.Lubee.Lubee.couple.dto.LubeeCodeResponse;
+import com.Lubee.Lubee.couple.repository.CoupleRepository;
+import com.Lubee.Lubee.user.domain.User;
+import com.Lubee.Lubee.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class CoupleService {
+
+    private static final long LUBEE_CODE_EXPIRATION_MINUTES = 1440; // 24시간(분 단위)
+
+    private final UserRepository userRepository;
+    private final CoupleRepository coupleRepository;
+
+    @Autowired
+    private RedisTemplate<Long, String> redisTemplate;      // key-userid, value-lubeecode
+
+    @Autowired
+    private RedisTemplate<String, Long> reverseRedisTemplate;      // key-lubeecode, value-userid
+
+    @Transactional
+    public ApiResponseDto<LubeeCodeResponse> generateLubeeCode(UserDetails userDetails) {
+
+        final User user = userRepository.findByUsername(userDetails.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+
+        String lubeeCode = UUID.randomUUID().toString().replace("-", "").substring(0, 10);
+
+        // 저장
+        redisTemplate.opsForValue().set(user.getId(), lubeeCode, Duration.ofMinutes(LUBEE_CODE_EXPIRATION_MINUTES));
+        reverseRedisTemplate.opsForValue().set(lubeeCode, user.getId(),Duration.ofMinutes(LUBEE_CODE_EXPIRATION_MINUTES));
+
+        return ResponseUtils.ok(LubeeCodeResponse.of(lubeeCode), ErrorResponse.builder().status(200).message("요청 성공").build());
+    }
+
+    @Transactional(readOnly = true)
+    public ApiResponseDto<LubeeCodeResponse> findLubeeCode(Long userid) {
+
+        final User user = userRepository.findById(userid)
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+
+        String lubeeCode = redisTemplate.opsForValue().get(user.getId());
+        if (lubeeCode == null) {
+            throw new RestApiException(ErrorType.LUBEE_CODE_NOT_FOUND);
+        }
+
+        return ResponseUtils.ok(LubeeCodeResponse.of(lubeeCode), ErrorResponse.builder().status(200).message("요청 성공").build());
+    }
+
+    @Transactional
+    public ApiResponseDto<Long> linkCouple(UserDetails userDetails, String inputCode) {
+
+        User requester = userRepository.findByUsername(userDetails.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+        if (requester.isAlreadyCouple()) {
+            throw new RestApiException(ErrorType.REQUESTER_ALREADY_COUPLED);
+        }
+
+        Long receiverId = reverseRedisTemplate.opsForValue().get(inputCode);
+        if(receiverId == null) {
+            throw new RestApiException(ErrorType.LUBEE_CODE_NOT_FOUND);
+        }
+
+        User receiver = userRepository.findById(receiverId)
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+
+        if (receiver.isAlreadyCouple()) {
+            throw new RestApiException(ErrorType.RECEIVER_ALREADY_COUPLED);
+        }
+
+        Couple couple = Couple.builder()
+                .receiver(receiver)
+                .requester(requester)
+                .build();
+
+        coupleRepository.save(couple);
+
+        requester.linkCouple(couple);
+        receiver.linkCouple(couple);
+        userRepository.save(requester);
+        userRepository.save(receiver);
+
+        redisTemplate.delete(receiver.getId());         // 커플된 유저의 러비코드는 삭제하기
+        redisTemplate.delete(requester.getId());        // 만약 해당 key가 없어도 무시됨
+
+        return ResponseUtils.ok(couple.getId(), ErrorResponse.builder().status(200).message("커플 생성 성공").build());
+    }
+
+}

--- a/src/main/java/com/Lubee/Lubee/date_comment/domain/DateComment.java
+++ b/src/main/java/com/Lubee/Lubee/date_comment/domain/DateComment.java
@@ -1,15 +1,14 @@
 package com.Lubee.Lubee.date_comment.domain;
 
+import com.Lubee.Lubee.calendar.domain.Calendar;
 import com.Lubee.Lubee.common.BaseEntity;
 import com.Lubee.Lubee.couple.domain.Couple;
-import com.Lubee.Lubee.memory.domain.Memory;
 import com.Lubee.Lubee.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.Date;
 
 @Entity
 @Getter
@@ -29,12 +28,18 @@ public class DateComment extends BaseEntity {
     @JoinColumn(name = "couple_id", nullable = false)
     private Couple couple;
 
-    @ManyToOne
-    @JoinColumn(name = "memory_id", nullable = false)
-    private Memory memory;
-
-    @Temporal(TemporalType.DATE)
-    private Date date;
-
     private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "calendar_id", nullable = false)
+    private Calendar calendar;      //calendar, datecomment는 양방향 일대다
+
+    @Builder
+    public DateComment(User user, Couple couple, String content, Calendar calendar){
+        this.user = user;
+        this.couple = couple;
+        this.content = content;
+        this.calendar = calendar;
+    }
+
 }

--- a/src/main/java/com/Lubee/Lubee/memory/domain/Memory.java
+++ b/src/main/java/com/Lubee/Lubee/memory/domain/Memory.java
@@ -1,12 +1,10 @@
 package com.Lubee.Lubee.memory.domain;
 
-import com.Lubee.Lubee.calendar.domain.Calendar;
 import com.Lubee.Lubee.calendar_memory.domain.CalendarMemory;
 import com.Lubee.Lubee.common.BaseEntity;
 import com.Lubee.Lubee.couple.domain.Couple;
 import com.Lubee.Lubee.date_comment.domain.DateComment;
 import com.Lubee.Lubee.location.domain.Location;
-import com.Lubee.Lubee.user.domain.User;
 import com.Lubee.Lubee.user_memory.domain.UserMemory;
 import com.Lubee.Lubee.user_memory_reaction.domain.UserMemoryReaction;
 import jakarta.persistence.*;

--- a/src/main/java/com/Lubee/Lubee/user/domain/User.java
+++ b/src/main/java/com/Lubee/Lubee/user/domain/User.java
@@ -1,6 +1,5 @@
 package com.Lubee.Lubee.user.domain;
 
-import com.Lubee.Lubee.calendar_memory.domain.CalendarMemory;
 import com.Lubee.Lubee.common.BaseEntity;
 import com.Lubee.Lubee.common.enumSet.LoginType;
 import com.Lubee.Lubee.common.enumSet.UserRoleEnum;
@@ -8,7 +7,6 @@ import com.Lubee.Lubee.couple.domain.Couple;
 import com.Lubee.Lubee.date_comment.domain.DateComment;
 import com.Lubee.Lubee.enumset.Profile;
 import com.Lubee.Lubee.firebase.domain.FireBase;
-import com.Lubee.Lubee.memory.domain.Memory;
 import com.Lubee.Lubee.user_calendar_memory.domain.UserCalendarMemory;
 import com.Lubee.Lubee.user_memory.domain.UserMemory;
 import com.Lubee.Lubee.user_memory_reaction.domain.UserMemoryReaction;
@@ -95,6 +93,11 @@ public class User extends BaseEntity {
         user.setPassword(password); // 패스워드 설정
         user.setRole(role); // 역할 설정
         return user; // 사용자 반환
+    }
+
+    public void linkCouple(Couple couple) {         // 커플 연결됐을 때 user 정보 변경
+        this.couple = couple;
+        this.alreadyCouple = true;
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,12 @@ spring:
     properties:
       hibernate.format_sql: true
       hibernate.dialect: org.hibernate.dialect.MySQLDialect
+  data:
+    redis:
+      host: localhost
+      port: 6379
   sql:
     init:
       mode: always
+
+JWT_TOKEN : 7ZWt7ZW0OTntmZTsnbTtjIXtlZzqta3snYTrhIjrqLjshLjqs4TroZzrgpjslYTqsIDsnpDtm4zrpa3tlZzqsJzrsJzsnpDrpbzrp4zrk6TslrTqsIDsnpA


### PR DESCRIPTION
## #️⃣연관된 이슈

> #5 #6 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) parking0/develop -> dev

## 📝작업 내용

> 러비코드를 생성하고, 조회하고, 커플을 연결시키는 기능을 만들었습니다.
> 프로젝트가 정상작동하지 않아 버그를 수정했습니다.


### 변경 사항
Redis에 러비코드를 저장하도록 만들었습니다.
따라서 Redis를 사용하기 위한 환경설정을 했습니다.
User 도메인에 커플을 연결할 때 데이터가 변경되는 함수를 추가했습니다.
lubee-code와 관련된 dto, errortype을 생성했습니다.

(**[fix] correct errors** - 프로젝트가 정상작동하도록 수정)

## 💬리뷰 요구사항

> 러비코드를 Redis에 저장할 때 key,value를 어떤 걸로 지정할지 고민이 많이 됐습니다. 두 요소 모두 조회해야 할 필요가 있기 때문에, '**reverseRedisTemplate**'도 만들었는데, 의견이 궁금합니다!
