### PR TITLE
[feat] implement Honey

### DIFF
--- a/src/main/java/com/Lubee/Lubee/calendar/controller/CalendarController.java
+++ b/src/main/java/com/Lubee/Lubee/calendar/controller/CalendarController.java
@@ -1,0 +1,61 @@
+package com.Lubee.Lubee.calendar.controller;
+
+import com.Lubee.Lubee.calendar.dto.MonthlyTotalHoneyRequest;
+import com.Lubee.Lubee.calendar.service.CalendarService;
+import com.Lubee.Lubee.common.api.ApiResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Date;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/calendars")
+public class CalendarController {
+
+    private final CalendarService calendarService;
+
+    /**
+     * 오늘의 꿀 조회
+     *
+     * @param userDetails 인증된 사용자의 정보를 담고 있는 UserDetails 객체
+     * @param date 꿀 정보 얻기를 원하는 날짜
+     * @return ApiResponseDto<Integer>  해당 날짜의 꿀 개수
+     */
+    @GetMapping("/honey/today")
+    public ApiResponseDto<Integer> getTodayHoney(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam final Date date) {
+
+        return calendarService.getHoneyInfoByUserAndDate(userDetails, date);
+    }
+
+    /**
+     * 커플의 전체 꿀 조회
+     *
+     * @param userDetails 인증된 사용자의 정보를 담고 있는 UserDetails 객체
+     * @return ApiResponseDto<Long>  커플이 가진 전체 꿀 개수
+     */
+    @GetMapping("/honey/total")
+    public ApiResponseDto<Long> getTotalHoney(@AuthenticationPrincipal UserDetails userDetails){
+
+        return calendarService.getTotalHoneyByUser(userDetails);
+    }
+
+    /**
+     * 커플의 월별 꿀 조회
+     *
+     * @param userDetails 인증된 사용자의 정보를 담고 있는 UserDetails 객체
+     * @param monthlyTotalHoneyRequest 원하는 년/월을 integer 값으로
+     * @return ApiResponseDto<Integer>  커플이 가진 전체 꿀 개수
+     */
+    @GetMapping("/honey/month")
+    public ApiResponseDto<Integer> getMonthHoney(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody final MonthlyTotalHoneyRequest monthlyTotalHoneyRequest){
+
+        return calendarService.getMonthlyHoneyByUser(userDetails, monthlyTotalHoneyRequest);
+    }
+}

--- a/src/main/java/com/Lubee/Lubee/calendar/domain/Calendar.java
+++ b/src/main/java/com/Lubee/Lubee/calendar/domain/Calendar.java
@@ -6,6 +6,7 @@ import com.Lubee.Lubee.couple.domain.Couple;
 import com.Lubee.Lubee.date_comment.domain.DateComment;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -37,5 +38,16 @@ public class Calendar extends BaseEntity {
 
     @OneToMany(mappedBy = "calendar", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<DateComment> dateComments = new ArrayList<>();
+
+
+    @Builder
+    public Calendar(Couple couple, Date eventDate) {
+        this.couple = couple;
+        this.eventDate = eventDate;
+    }
+
+    public void addDateComment(DateComment dateComment) {
+        dateComments.add(dateComment);
+    }
 
 }

--- a/src/main/java/com/Lubee/Lubee/calendar/dto/MonthlyTotalHoneyRequest.java
+++ b/src/main/java/com/Lubee/Lubee/calendar/dto/MonthlyTotalHoneyRequest.java
@@ -1,0 +1,12 @@
+package com.Lubee.Lubee.calendar.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MonthlyTotalHoneyRequest {
+
+    private int year;
+    private int month;
+}

--- a/src/main/java/com/Lubee/Lubee/calendar/repository/CalendarRepository.java
+++ b/src/main/java/com/Lubee/Lubee/calendar/repository/CalendarRepository.java
@@ -3,10 +3,18 @@ package com.Lubee.Lubee.calendar.repository;
 import com.Lubee.Lubee.calendar.domain.Calendar;
 import com.Lubee.Lubee.couple.domain.Couple;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 
 public interface CalendarRepository extends JpaRepository<Calendar, Long> {
 
     Calendar findByCoupleAndEventDate(Couple couple, Date eventDate);   // 해당 날짜에 생성된 커플달력이 있는지
+
+    // 커플이 해당 년/월에 생성한 Calendar를 조회
+    @Query("SELECT c FROM Calendar c WHERE c.couple = :couple AND FUNCTION('YEAR', c.eventDate) = :year AND FUNCTION('MONTH', c.eventDate) = :month")
+    List<Calendar> findAllByCoupleAndYearAndMonth(@Param("couple") Couple couple, @Param("year") int year, @Param("month") int month);
 }

--- a/src/main/java/com/Lubee/Lubee/calendar/repository/CalendarRepository.java
+++ b/src/main/java/com/Lubee/Lubee/calendar/repository/CalendarRepository.java
@@ -1,0 +1,12 @@
+package com.Lubee.Lubee.calendar.repository;
+
+import com.Lubee.Lubee.calendar.domain.Calendar;
+import com.Lubee.Lubee.couple.domain.Couple;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Date;
+
+public interface CalendarRepository extends JpaRepository<Calendar, Long> {
+
+    Calendar findByCoupleAndEventDate(Couple couple, Date eventDate);   // 해당 날짜에 생성된 커플달력이 있는지
+}

--- a/src/main/java/com/Lubee/Lubee/calendar/service/CalendarService.java
+++ b/src/main/java/com/Lubee/Lubee/calendar/service/CalendarService.java
@@ -1,0 +1,113 @@
+package com.Lubee.Lubee.calendar.service;
+
+import com.Lubee.Lubee.calendar.domain.Calendar;
+import com.Lubee.Lubee.calendar.dto.MonthlyTotalHoneyRequest;
+import com.Lubee.Lubee.calendar.repository.CalendarRepository;
+import com.Lubee.Lubee.common.api.ApiResponseDto;
+import com.Lubee.Lubee.common.api.ErrorResponse;
+import com.Lubee.Lubee.common.api.ResponseUtils;
+import com.Lubee.Lubee.common.enumSet.ErrorType;
+import com.Lubee.Lubee.common.exception.RestApiException;
+import com.Lubee.Lubee.couple.domain.Couple;
+import com.Lubee.Lubee.couple.repository.CoupleRepository;
+import com.Lubee.Lubee.user.domain.User;
+import com.Lubee.Lubee.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class CalendarService {
+
+    private final UserRepository userRepository;
+    private final CoupleRepository coupleRepository;
+    private final CalendarRepository calendarRepository;
+
+    /**
+     * <오늘의 꿀 개수 조회 (날짜 하루)>
+     *     - 파라미터에 따라 User, Couple, Calendar 조회 -> 에러 반환
+     *     - (1) 올라온 사진 X => 0 반환
+     *     - (2) 올라온 사진 O => 사진 개수 반환
+     */
+    @Transactional(readOnly = true)
+    public ApiResponseDto<Integer> getHoneyInfoByUserAndDate(UserDetails userDetails, Date date){
+
+        final User user = userRepository.findUserByUsername(userDetails.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+        final Couple couple = coupleRepository.findCoupleByUser(user)
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_COUPLE));
+        final Calendar calendar = calendarRepository.findByCoupleAndEventDate(couple, date);
+
+        // 오늘의 허니 계산
+        int todayHoney;
+        if(calendar == null){
+            todayHoney = 0;
+        }
+        else{
+            todayHoney = calendar.getCalendarMemories().size();
+        }
+
+        return ResponseUtils.ok(
+                todayHoney,
+                ErrorResponse.builder().status(200).message("요청 성공").build()
+        );
+    }
+
+    /**
+     * <커플의 전체 꿀 개수 조회>
+     *     - 파라미터에 따라 User, Couple, Calendar 조회 -> 에러 반환
+     *     - 커플이 가진 전체 꿀 개수 반환
+     */
+    @Transactional(readOnly = true)
+    public ApiResponseDto<Long> getTotalHoneyByUser(UserDetails userDetails){
+
+        final User user = userRepository.findUserByUsername(userDetails.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+        final Couple couple = coupleRepository.findCoupleByUser(user)
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_COUPLE));
+
+        return ResponseUtils.ok(
+                couple.getTotal_honey(),
+                ErrorResponse.builder().status(200).message("요청 성공").build()
+        );
+    }
+
+    /**
+     * <커플의 월별 꿀 개수 조회>
+     *     - 파라미터에 따라 User, Couple, List<Calendar> 조회 -> 에러 반환
+     *     - 커플이 가진 월별 꿀 개수 반환
+     *     - 해당 년/월에 만들어진 memory가 없으면 0 반환
+     */
+    @Transactional(readOnly = true)
+    public ApiResponseDto<Integer> getMonthlyHoneyByUser(UserDetails userDetails, MonthlyTotalHoneyRequest monthlyTotalHoneyRequest) {
+
+        final User user = userRepository.findUserByUsername(userDetails.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+        final Couple couple = coupleRepository.findCoupleByUser(user)
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_COUPLE));
+        List<Calendar> calendars = calendarRepository.findAllByCoupleAndYearAndMonth(couple, monthlyTotalHoneyRequest.getYear(), monthlyTotalHoneyRequest.getMonth());
+
+        int monthHoney = 0;
+        if (!calendars.isEmpty()) {     // calendar 리스트가 비어있지 않으면 월별 honey 개수 세기
+            for (Calendar calendar : calendars) {
+                String dateKey = new SimpleDateFormat("yyyy-MM-dd").format(calendar.getEventDate());
+                monthHoney += calendar.getCalendarMemories().size();     // 현재 Calendar의 CalendarMemory 개수를 추가하여 누적
+            }
+        }
+
+        return ResponseUtils.ok(
+                monthHoney,
+                ErrorResponse.builder().status(200).message("요청 성공").build()
+        );
+    }
+
+
+}

--- a/src/main/java/com/Lubee/Lubee/common/enumSet/ErrorType.java
+++ b/src/main/java/com/Lubee/Lubee/common/enumSet/ErrorType.java
@@ -42,6 +42,13 @@ public enum ErrorType {
     REQUESTER_ALREADY_COUPLED(400, "커플 신청자가 이미 커플입니다."),
     RECEIVER_ALREADY_COUPLED(400, "커플 요청받은 사람이 이미 커플입니다."),
     NOT_FOUND_COUPLE(404, "해당 커플 정보를 찾을 수 없습니다"),
+    NOT_FOUND_CALENDAR(404, "달력이 존재하지 않습니다."),
+    NOT_FOUND_DATE_COMMENT(404, "데이트코멘트가 존재하지 않습니다."),
+    NOT_MATCHING_USER(403, "유저 정보가 알맞지 않습니다."),
+    NOT_MATCHING_COUPLE(403, "커플 정보가 알맞지 않습니다."),
+    NOT_MATCHING_CALENDAR(403, "달력 정보가 알맞지 않습니다."),
+    INSUFFICIENT_COMMENTS(403, "두 명의 구성원이 모두 데이트 코멘트를 작성해야 열람할 수 있습니다."),
+    NOT_FOUND_COUPLE_DATE_COMMENT(404, "커플 모두 데이트코멘트를 작성하지 않았습니다.")
     ;
 
 

--- a/src/main/java/com/Lubee/Lubee/date_comment/controller/DateCommentController.java
+++ b/src/main/java/com/Lubee/Lubee/date_comment/controller/DateCommentController.java
@@ -1,0 +1,81 @@
+package com.Lubee.Lubee.date_comment.controller;
+
+import com.Lubee.Lubee.common.api.ApiResponseDto;
+import com.Lubee.Lubee.common.api.SuccessResponse;
+import com.Lubee.Lubee.date_comment.dto.CreateDateCommentRequest;
+import com.Lubee.Lubee.date_comment.dto.DateCommentResponse;
+import com.Lubee.Lubee.date_comment.dto.TodayCoupleDateCommentRequest;
+import com.Lubee.Lubee.date_comment.dto.UpdateDateCommentRequest;
+import com.Lubee.Lubee.date_comment.service.DateCommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/datecomments")
+public class DateCommentController {
+
+    private final DateCommentService dateCommentService;
+
+    /**
+     * 데이트코멘트 작성
+     *
+     * @param userDetails 인증된 사용자의 정보를 담고 있는 UserDetails 객체
+     * @param createDateCommentRequest 데이트코멘트 생성 요청 Dto (content, coupleId, date)
+     * @return ApiResponseDto<Long>  생성된 Datecomment의 id를 포함
+     */
+    @PostMapping
+    public ApiResponseDto<Long> createDateComment(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody final CreateDateCommentRequest createDateCommentRequest){
+
+        return dateCommentService.createDateComment(userDetails, createDateCommentRequest);
+    }
+
+    /**
+     * 데이트코멘트 조회 by Datecomment's id
+     *
+     * @param id 데이트코멘트의 id
+     * @return ApiResponseDto<DateCommentResponse>
+     */
+    @GetMapping("/{id}")
+    public ApiResponseDto<DateCommentResponse> findDateComment(@PathVariable final Long id){
+
+        return dateCommentService.findDateComment(id);
+    }
+
+    /**
+     * 커플의 데이트코멘트 조회 (날짜 하루)
+     *
+     * @param userDetails 인증된 사용자의 정보를 담고 있는 UserDetails 객체
+     * @param todayCoupleDateCommentRequest 해당 날짜에 작성된 커플의 데이트코멘트 요청 dto (userId, coupleId, date)
+     * @return List<DateCommentResponse>
+     */
+    @GetMapping("/today")
+    public ApiResponseDto<List<DateCommentResponse>> findTodayDateCommentByCouple(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody final TodayCoupleDateCommentRequest todayCoupleDateCommentRequest){
+
+        return dateCommentService.findTodayDateCommentByCouple(userDetails, todayCoupleDateCommentRequest);
+    }
+
+    /**
+     * 데이트코멘트 수정
+     *
+     * @param userDetails 인증된 사용자의 정보를 담고 있는 UserDetails 객체
+     * @param updateDateCommentRequest 데이트코멘트 내용 수정 변경 요청 dto (dateCommentId, content)
+     * @return SuccessResponse
+     */
+    @PutMapping
+    public SuccessResponse updateContent(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody UpdateDateCommentRequest updateDateCommentRequest){
+
+        return dateCommentService.changeContent(userDetails, updateDateCommentRequest);
+    }
+
+}

--- a/src/main/java/com/Lubee/Lubee/date_comment/domain/DateComment.java
+++ b/src/main/java/com/Lubee/Lubee/date_comment/domain/DateComment.java
@@ -42,4 +42,8 @@ public class DateComment extends BaseEntity {
         this.calendar = calendar;
     }
 
+    public void changeContent(String content){
+        this.content = content;
+    }
+
 }

--- a/src/main/java/com/Lubee/Lubee/date_comment/dto/CreateDateCommentRequest.java
+++ b/src/main/java/com/Lubee/Lubee/date_comment/dto/CreateDateCommentRequest.java
@@ -1,0 +1,22 @@
+package com.Lubee.Lubee.date_comment.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@NoArgsConstructor
+public class CreateDateCommentRequest {
+
+    private String content;
+    private Long coupleId;
+    //private Long calendarId;
+    private Date date;
+
+    public CreateDateCommentRequest(String content, Long coupleId, Date date) {
+        this.content = content;
+        this.coupleId = coupleId;
+        this.date = date;
+    }
+}

--- a/src/main/java/com/Lubee/Lubee/date_comment/dto/DateCommentResponse.java
+++ b/src/main/java/com/Lubee/Lubee/date_comment/dto/DateCommentResponse.java
@@ -1,0 +1,22 @@
+package com.Lubee.Lubee.date_comment.dto;
+
+import com.Lubee.Lubee.date_comment.domain.DateComment;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class DateCommentResponse {
+
+    private Long userId;
+    private String content;
+
+    public static DateCommentResponse of(DateComment dateComment) {
+        return new DateCommentResponse(
+                dateComment.getUser().getId(),
+                dateComment.getContent()
+        );
+    }
+
+}

--- a/src/main/java/com/Lubee/Lubee/date_comment/dto/TodayCoupleDateCommentRequest.java
+++ b/src/main/java/com/Lubee/Lubee/date_comment/dto/TodayCoupleDateCommentRequest.java
@@ -1,0 +1,17 @@
+package com.Lubee.Lubee.date_comment.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@NoArgsConstructor
+public class TodayCoupleDateCommentRequest {
+
+    private Long userId;
+    private Long coupleId;
+    //private Long calendarId;
+    private Date date;
+
+}

--- a/src/main/java/com/Lubee/Lubee/date_comment/dto/UpdateDateCommentRequest.java
+++ b/src/main/java/com/Lubee/Lubee/date_comment/dto/UpdateDateCommentRequest.java
@@ -1,0 +1,17 @@
+package com.Lubee.Lubee.date_comment.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateDateCommentRequest {
+
+    private Long dateCommentId;
+    private String content;
+
+    public UpdateDateCommentRequest(Long dateCommentId, String content) {
+        this.dateCommentId = dateCommentId;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/Lubee/Lubee/date_comment/repository/DateCommentRepository.java
+++ b/src/main/java/com/Lubee/Lubee/date_comment/repository/DateCommentRepository.java
@@ -1,0 +1,15 @@
+package com.Lubee.Lubee.date_comment.repository;
+
+import com.Lubee.Lubee.calendar.domain.Calendar;
+import com.Lubee.Lubee.couple.domain.Couple;
+import com.Lubee.Lubee.date_comment.domain.DateComment;
+import com.Lubee.Lubee.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DateCommentRepository extends JpaRepository<DateComment, Long> {
+
+    DateComment findByUserAndCalendar(User user, Calendar calendar);
+    List<DateComment> findByCoupleAndCalendar(Couple couple, Calendar calendar);
+}

--- a/src/main/java/com/Lubee/Lubee/date_comment/service/DateCommentService.java
+++ b/src/main/java/com/Lubee/Lubee/date_comment/service/DateCommentService.java
@@ -1,0 +1,187 @@
+package com.Lubee.Lubee.date_comment.service;
+
+import com.Lubee.Lubee.calendar.domain.Calendar;
+import com.Lubee.Lubee.calendar.repository.CalendarRepository;
+import com.Lubee.Lubee.common.api.ApiResponseDto;
+import com.Lubee.Lubee.common.api.ErrorResponse;
+import com.Lubee.Lubee.common.api.ResponseUtils;
+import com.Lubee.Lubee.common.api.SuccessResponse;
+import com.Lubee.Lubee.common.enumSet.ErrorType;
+import com.Lubee.Lubee.common.exception.RestApiException;
+import com.Lubee.Lubee.couple.domain.Couple;
+import com.Lubee.Lubee.couple.repository.CoupleRepository;
+import com.Lubee.Lubee.date_comment.domain.DateComment;
+import com.Lubee.Lubee.date_comment.dto.CreateDateCommentRequest;
+import com.Lubee.Lubee.date_comment.dto.DateCommentResponse;
+import com.Lubee.Lubee.date_comment.dto.TodayCoupleDateCommentRequest;
+import com.Lubee.Lubee.date_comment.dto.UpdateDateCommentRequest;
+import com.Lubee.Lubee.date_comment.repository.DateCommentRepository;
+import com.Lubee.Lubee.user.domain.User;
+import com.Lubee.Lubee.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class DateCommentService {
+
+    private final UserRepository userRepository;
+    private final DateCommentRepository dateCommentRepository;
+    private final CoupleRepository coupleRepository;
+    private final CalendarRepository calendarRepository;
+
+    /**
+     * <데이트 코멘트 생성>
+     *     - 아직 캘린더가 없으면, 해당 날짜의 캘린더를 생성
+     *     - 데이트코멘트가 생성되면, Calendar에도 추가
+     */
+    @Transactional
+    public ApiResponseDto<Long> createDateComment(UserDetails userDetails, CreateDateCommentRequest createDateCommentRequest) {
+
+        final User user = userRepository.findByUsername(userDetails.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+        final Couple couple = coupleRepository.findById(createDateCommentRequest.getCoupleId())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_COUPLE));
+
+        // 캘린더가 없으면 해당 날짜의 캘린더를 생성
+        Calendar calendar = calendarRepository.findByCoupleAndEventDate(couple, createDateCommentRequest.getDate());
+        if (calendar == null) {
+            calendar = Calendar.builder()
+                    .couple(couple)
+                    .eventDate(createDateCommentRequest.getDate())
+                    .build();
+            calendarRepository.save(calendar);
+        }
+
+        DateComment dateComment = DateComment.builder()
+                .user(user)
+                .couple(couple)
+                .content(createDateCommentRequest.getContent())
+                .calendar(calendar)
+                .build();
+        calendar.addDateComment(dateComment);    // 양방향 일대다 관계이기 때문
+        dateCommentRepository.save(dateComment);
+
+        return ResponseUtils.ok(dateComment.getId(), ErrorResponse.builder().status(200).message("데이트코멘트 생성 성공").build());
+    }
+
+    /**
+     * <데이트 코멘트 조회 by id>
+     *     - 해당 데이트코멘트 id로 조회되지 않으면, 에러 반환
+     */
+    @Transactional(readOnly = true)
+    public ApiResponseDto<DateCommentResponse> findDateComment(Long id) {
+
+        final DateComment dateComment = dateCommentRepository.findById(id)
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_DATE_COMMENT));
+
+        return ResponseUtils.ok(
+                DateCommentResponse.of(dateComment),
+                ErrorResponse.builder().status(200).message("요청 성공").build()
+        );
+    }
+
+    /**
+     * <커플의 데이트코멘트 조회 (날짜 하루)>
+     *     - 파라미터에 따라 User, Couple, Calendar 조회 -> 에러 반환
+     *     - (1) 둘다 작성 x => 에러 반환
+     *     - (2) 나만 작성 o => 나의 데이트코멘트만 반환
+     *     - (3) 둘다 작성 o => 둘의 데이트코멘트 모두 반환
+     */
+    @Transactional(readOnly = true)
+    public ApiResponseDto<List<DateCommentResponse>> findTodayDateCommentByCouple(UserDetails userDetails, TodayCoupleDateCommentRequest todayCoupleDateCommentRequest) {
+
+        final User user = userRepository.findByUsername(userDetails.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+        if (!user.getId().equals(todayCoupleDateCommentRequest.getUserId())) {        // 열람요청자의 것이 아닐 때
+            throw new RestApiException(ErrorType.NOT_MATCHING_USER);
+        }
+
+        final Couple couple = coupleRepository.findById(todayCoupleDateCommentRequest.getCoupleId())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_COUPLE));
+        if (!couple.getId().equals(todayCoupleDateCommentRequest.getCoupleId())) {    // 커플id가 잘못됐을 때
+            throw new RestApiException(ErrorType.NOT_MATCHING_COUPLE);
+        }
+
+        final Calendar calendar = calendarRepository.findByCoupleAndEventDate(couple, todayCoupleDateCommentRequest.getDate());
+        if (calendar == null) {               // 커플이 해당 달력을 만들지 않았으면..
+            throw new RestApiException(ErrorType.NOT_FOUND_CALENDAR);
+        }
+
+        List<DateCommentResponse> result = new ArrayList<>();
+
+        // 커플 모두가 작성한 데이트 코멘트 수 확인
+        List<DateComment> dateComments = dateCommentRepository.findByCoupleAndCalendar(couple, calendar);
+        DateComment myComment = dateCommentRepository.findByUserAndCalendar(user, calendar);
+
+        if (dateComments.isEmpty()) {     // 둘다 코멘트 작성x
+            throw new RestApiException(ErrorType.NOT_FOUND_COUPLE_DATE_COMMENT);
+        }
+
+        if (dateComments.size() == 1 && myComment != null) {    // 나만 작성
+            result.add(DateCommentResponse.of(myComment));
+            return ResponseUtils.ok(result, ErrorResponse.builder().status(200).message("상대방은 데이트코멘트를 작성하지 않았습니다.").build());
+        }
+
+        // 둘 다 작성한 경우 => 상대방의 것도 열람 가능
+        User otherUser = findOtherUserInCouple(user.getId(), couple);
+        DateComment otherUserComment = dateCommentRepository.findByUserAndCalendar(otherUser, calendar);
+
+        result.add(DateCommentResponse.of(myComment));
+        result.add(DateCommentResponse.of(otherUserComment));
+
+        return ResponseUtils.ok(
+                result,
+                ErrorResponse.builder().status(200).message("두 사람 모두 데이트코멘트를 작성했습니다.").build()
+        );
+    }
+
+    /**
+     * <데이트코멘트 수정>
+     *     - 파라미터로 User, DateComment 조회 => 에러 반환
+     *     - 작성자와 현재 사용자의 id 비교 -- 권한o 유저만 내용 변경O
+     */
+    @Transactional
+    public SuccessResponse changeContent(UserDetails userDetails, UpdateDateCommentRequest updateDateCommentRequest) {
+
+        final User user = userRepository.findByUsername(userDetails.getUsername())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+        final DateComment dateComment = dateCommentRepository.findById(updateDateCommentRequest.getDateCommentId())
+                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_DATE_COMMENT));
+
+        // 작성자와 현재 사용자를 비교하여 일치하지 않으면 예외 처리 - 작성자만 content를 바꿀 수 있음
+        if (!dateComment.getUser().equals(user)) {
+            throw new RestApiException(ErrorType.NOT_MATCHING_USER);
+        }
+
+        dateComment.changeContent(updateDateCommentRequest.getContent());
+        dateCommentRepository.save(dateComment);
+
+        return SuccessResponse.builder().status(200).message("데이트 코멘트 수정 성공").build();
+    }
+
+    /**
+     * Couple과 User 1명만 알 때 - 연인(User) 찾기
+     */
+    public User findOtherUserInCouple(Long knownUserId, Couple couple) {
+
+        if (couple != null && couple.getUser().size() == 2) {
+            // Couple에는 항상 2명의 사용자가 포함되므로, 알고 있는 사용자를 제외한 다른 사용자를 찾습니다.
+            for (User user : couple.getUser()) {
+                if (!user.getId().equals(knownUserId)) {
+                    return user;
+                }
+            }
+        }
+        return null; // 적절한 Couple을 찾지 못한 경우 null 반환
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#24 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 변경
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/honey -> dev

## 📝작업 내용

> Honey와 관련된 작업을 진행했습니다.

오늘의 Honey 조회, 전체 Honey 조회, 월별 Honey 조회를 개발했습니다.

### 변경 사항
변경사항 없습니다.

### 테스트 결과
추후에 테스트할 예정입니다. 정상작동은 확인했습니다.

## 💬리뷰 요구사항

1. **Calendar에 today_honey 컬럼을 추가할지** 고민했습니다. 현재 honey 정보는 Couple 도메인에만 존재합니다. 하지만 Calendar(하루)마다 꿀 5개가 채워질 수 있으니, 달력에 honey와 관련된 정보를 추가해야한다고 처음에 생각했습니다. 고민하다가 **'CalendarMemory'개수로 honey 개수를 파악**하는 방향으로 진행했습니다. **어떤 방법이 더 좋을지 의견 궁금합니다 :)**
2. **Couple 엔티티에서 present_honey 컬럼이 필요한 이유**가 헷갈립니다. 개인적으로는 필요없다고 생각되어 사용하지 않았습니다.
3. **Calendar 엔티티에서 description 컬럼의 필요성**을 모르겠습니다.