### PR TITLE
[feat] load Location Info from OpenApi

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.1.RELEASE'
+	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
 
 }
 

--- a/src/main/java/com/Lubee/Lubee/couple/controller/CoupleController.java
+++ b/src/main/java/com/Lubee/Lubee/couple/controller/CoupleController.java
@@ -15,18 +15,37 @@ public class CoupleController {
 
     private final CoupleService coupleService;
 
+    /**
+     * 러비코드 생성
+     *
+     * @param userDetails 인증된 사용자의 정보를 담고 있는 UserDetails 객체
+     * @return ApiResponseDto<LubeeCodeResponse>  생성된 LubeeCode의 id를 포함
+     */
     @PostMapping("/lubee-code")
     public ApiResponseDto<LubeeCodeResponse> generateLubeeCode(@AuthenticationPrincipal UserDetails userDetails){
 
         return coupleService.generateLubeeCode(userDetails);
     }
 
+    /**
+     * 러비코드 조회
+     *
+     * @param id User의 id
+     * @return ApiResponseDto<LubeeCodeResponse>  생성된 LubeeCode의 id를 포함
+     */
     @GetMapping("/lubee-code/{id}")
     public ApiResponseDto<LubeeCodeResponse> getLubeeCode(@PathVariable Long id){
 
         return coupleService.findLubeeCode(id);
     }
 
+    /**
+     * 커플 연결
+     *
+     * @param userDetails 인증된 사용자의 정보를 담고 있는 UserDetails 객체
+     * @param inputCode 사용자가 입력한 코드
+     * @return ApiResponseDto<LubeeCodeResponse>  생성된 LubeeCode의 id를 포함
+     */
     @PostMapping("/link")
     public ApiResponseDto<Long> linkCouple(
             @AuthenticationPrincipal UserDetails userDetails,

--- a/src/main/java/com/Lubee/Lubee/couple/service/CoupleService.java
+++ b/src/main/java/com/Lubee/Lubee/couple/service/CoupleService.java
@@ -19,8 +19,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
-import java.util.Date;
-import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -36,10 +34,15 @@ public class CoupleService {
 
     @Autowired
     private RedisTemplate<Long, String> redisTemplate;      // key-userid, value-lubeecode
-
     @Autowired
     private RedisTemplate<String, Long> reverseRedisTemplate;      // key-lubeecode, value-userid
 
+    /**
+     * <러비코드 생성>
+     *     - 10자리의 랜덤한 코드 생성
+     *     - Userid가 key인 redisTemplate 생성
+     *     - lubeecode가 key인 reverseRedisTemplate 생성
+     */
     @Transactional
     public ApiResponseDto<LubeeCodeResponse> generateLubeeCode(UserDetails userDetails) {
 
@@ -55,6 +58,11 @@ public class CoupleService {
         return ResponseUtils.ok(LubeeCodeResponse.of(lubeeCode), ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
+    /**
+     * <러비코드 조회>
+     *     - userId가 가지고 있는 러비코드 조회
+     *     - 생성된 러비코드가 없을시, 에러 반환
+     */
     @Transactional(readOnly = true)
     public ApiResponseDto<LubeeCodeResponse> findLubeeCode(Long userid) {
 
@@ -69,6 +77,11 @@ public class CoupleService {
         return ResponseUtils.ok(LubeeCodeResponse.of(lubeeCode), ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
+    /**
+     * <커플 연동>
+     *     - requester, receiver가 이미 커플인지 확인한 후 커플 연동
+     *     - 두 user가 커플 연결됐을 경우, DB에서 두 러비코드 삭제
+     */
     @Transactional
     public ApiResponseDto<Long> linkCouple(UserDetails userDetails, String inputCode) {
 

--- a/src/main/java/com/Lubee/Lubee/location/LocationApiClient.java
+++ b/src/main/java/com/Lubee/Lubee/location/LocationApiClient.java
@@ -1,0 +1,231 @@
+package com.Lubee.Lubee.location;
+
+import com.Lubee.Lubee.location.dto.SeoulLocationInfo;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class LocationApiClient {
+
+    @Value("${RESTAURANT_API_KEY}")
+    private String res_api_Key;             // 서울시 일반음식점
+    @Value("${CULTURE_API_KEY}")
+    private String cul_api_Key;             // 서울시 문화 공간
+
+    private static final String BASE_URL = "http://openapi.seoul.go.kr:8088/";
+    private static final String RES_URL_SUFFIX = "/json/LOCALDATA_072404/";
+    private static final String CUL_URL_SUFFIX = "/json/culturalSpaceInfo/";
+    private static final int MAX_ITEMS = 1000;
+
+    private int nData_res = 0;
+    private Long totalData_res = 0L;
+    private Long totalLocations_res = 0L;
+
+    private int nData_cul = 0;
+    private Long totalData_cul = 0L;
+    private Long totalLocations_cul = 0L;
+
+    /**
+     * 서울시 일반 음식점
+     */
+    public void loadRestaurantLocation() {
+
+        StringBuilder result;
+
+        try {
+            int startReq = 1;
+            int endReq = MAX_ITEMS;
+            boolean nextFinished = false;
+
+            while (true) {
+                URL url = new URL(BASE_URL + res_api_Key + RES_URL_SUFFIX + startReq + "/" + endReq);
+                BufferedReader br;
+                br = new BufferedReader(new InputStreamReader(url.openStream(), "UTF-8"));
+                result = new StringBuilder(br.readLine());
+                String returnLine;
+
+                while ((returnLine = br.readLine()) != null) {
+                    result.append(returnLine).append("\n\r");
+                }
+                saveRestuarantLocation(result.toString());           // jsonParser 이용 후 DB 저장
+                //System.out.println("totalData :  " + totalData_res);
+
+                if(nextFinished){
+                    break;
+                }
+
+                if (totalData_res + MAX_ITEMS > totalLocations_res) {       // 마지막 요청이면
+                    nextFinished = true;
+                }
+
+                startReq += MAX_ITEMS;
+                endReq += MAX_ITEMS;
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void saveRestuarantLocation(String jsonData){
+
+        List<SeoulLocationInfo> seoulLocationInfoList = new ArrayList<>();
+
+        try {
+            JSONObject jsonOb;
+            JSONParser parser = new JSONParser();
+            JSONObject jsonObject = (JSONObject) parser.parse(jsonData);
+
+            JSONObject localData = (JSONObject) jsonObject.get("LOCALDATA_072404");
+            totalLocations_res = (long) localData.get("list_total_count");
+            JSONArray jsonArray = (JSONArray) localData.get("row");
+
+            for (Object o : jsonArray) {
+                jsonOb = (JSONObject) o;
+
+                SeoulLocationInfo seoulLocationInfo = SeoulLocationInfo.builder()
+                        .name(jsonOb.get("BPLCNM").toString())      // 사업장명
+                        .parcelBaseAddress(jsonOb.get("RDNWHLADDR").toString()) //도로명 주소
+                        .x_coord(jsonOb.get("X").toString())
+                        .y_coord(jsonOb.get("Y").toString())
+                        .build();
+                seoulLocationInfoList.add(seoulLocationInfo);
+            }
+            nData_res = seoulLocationInfoList.size();
+            totalData_res += nData_res;
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * 서울시 문화공간
+     */
+    public void loadCultureLocation() {
+
+        StringBuilder result;
+
+        try {
+            int startReq = 1;
+            int endReq = MAX_ITEMS;
+            boolean nextFinished = false;
+
+            while (true) {
+                URL url = new URL(BASE_URL + cul_api_Key + CUL_URL_SUFFIX + startReq + "/" + endReq);
+                BufferedReader br;
+                br = new BufferedReader(new InputStreamReader(url.openStream(), "UTF-8"));
+                result = new StringBuilder(br.readLine());
+                String returnLine;
+
+                while ((returnLine = br.readLine()) != null) {      // JSON을 String형식으로 가져옴
+                    result.append(returnLine).append("\n\r");
+                }
+                saveCultureLocation(result.toString());           // jsonParser 이용 후 DB 저장
+                //System.out.println("totalData :  " + totalData_cul);
+
+                if (nextFinished) {
+                    break;
+                }
+
+                if (totalData_cul + MAX_ITEMS > totalLocations_cul) {
+                    nextFinished = true;
+                }
+                startReq += MAX_ITEMS;
+                endReq += MAX_ITEMS;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void saveCultureLocation(String jsonData){
+
+        List<SeoulLocationInfo> seoulLocationInfoList = new ArrayList<>();
+
+        try {
+            JSONObject jsonOb;
+            JSONParser parser = new JSONParser();
+            JSONObject jsonObject = (JSONObject) parser.parse(jsonData);
+
+            JSONObject localData = (JSONObject) jsonObject.get("culturalSpaceInfo");
+            totalLocations_cul = (long) localData.get("list_total_count");
+            //System.out.println("문화 총 개수 : " + totalLocations_cul);
+            JSONArray jsonArray = (JSONArray) localData.get("row");
+
+            for (Object o : jsonArray) {
+                jsonOb = (JSONObject) o;
+                SeoulLocationInfo seoulLocationInfo = SeoulLocationInfo.builder()
+                        .name(jsonOb.get("FAC_NAME").toString())      // 문화시설명
+                        .parcelBaseAddress(jsonOb.get("ADDR").toString()) // 주소
+                        .x_coord(jsonOb.get("X_COORD").toString())
+                        .y_coord(jsonOb.get("Y_COORD").toString())
+                        .build();
+                seoulLocationInfoList.add(seoulLocationInfo);
+                //System.out.println("SeoulLocationInfo :  " + seoulLocationInfo.getName());
+            }
+            nData_cul = seoulLocationInfoList.size();
+            totalData_cul += nData_cul;
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    /**
+     * 테스트용 코드 (데이터 잘 불러오는지)
+     */
+    public void laod_data(){
+
+        StringBuilder result = new StringBuilder();
+
+        try {
+            int startReq = 1;
+            int endReq = 5;
+
+            URL url = new URL(BASE_URL + cul_api_Key + CUL_URL_SUFFIX + startReq + "/" + endReq);
+            BufferedReader br;
+            br = new BufferedReader(new InputStreamReader(url.openStream(), "UTF-8"));
+            result = new StringBuilder(br.readLine());
+            String returnLine;
+
+            while ((returnLine = br.readLine()) != null) {
+                result.append(returnLine).append("\n\r");
+            }
+
+            //System.out.println("JSONDATA\n" + result.toString());
+
+            // json
+            JSONObject jsonOb;
+            JSONParser parser = new JSONParser();
+            JSONObject jsonObject = (JSONObject) parser.parse(result.toString());
+
+            JSONObject localData = (JSONObject) jsonObject.get("culturalSpaceInfo");
+            JSONArray jsonArray = (JSONArray) localData.get("row");
+
+            for (Object o : jsonArray) {
+                jsonOb = (JSONObject) o;
+
+                SeoulLocationInfo seoulLocationInfo = SeoulLocationInfo.builder()
+                        .name(jsonOb.get("FAC_NAME").toString())      // 문화시설명
+                        .parcelBaseAddress(jsonOb.get("ADDR").toString()) // 주소
+                        .x_coord(jsonOb.get("X_COORD").toString())
+                        .y_coord(jsonOb.get("Y_COORD").toString())
+                        .build();
+                //System.out.println(seoulLocationInfo.getName() + " : " + seoulLocationInfo.getParcelBaseAddress());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/com/Lubee/Lubee/location/MyAppStartUpRunner.java
+++ b/src/main/java/com/Lubee/Lubee/location/MyAppStartUpRunner.java
@@ -1,0 +1,23 @@
+package com.Lubee.Lubee.location;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MyAppStartUpRunner implements CommandLineRunner {
+
+    @Autowired
+    private LocationApiClient locationApiClient;
+
+    @Override
+    public void run(String... args) throws Exception {
+        System.out.println("MyAppStartUpRunner...");
+        System.out.println("loadCultureLocation...");
+        locationApiClient.loadCultureLocation();
+        //System.out.println("loadRestaurantLocation...");
+        //locationApiClient.loadRestaurantLocation();
+        System.out.println("MyAppStartUpRunner - FINISHED");
+    }
+
+}

--- a/src/main/java/com/Lubee/Lubee/location/dto/SeoulLocationInfo.java
+++ b/src/main/java/com/Lubee/Lubee/location/dto/SeoulLocationInfo.java
@@ -1,0 +1,22 @@
+package com.Lubee.Lubee.location.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SeoulLocationInfo {
+
+    private String name;
+    private String parcelBaseAddress;
+    private String x_coord;
+    private String y_coord;
+
+    @Builder
+    public SeoulLocationInfo(String name, String parcelBaseAddress, String x_coord, String y_coord) {
+        this.name = name;
+        this.parcelBaseAddress = parcelBaseAddress;
+        this.x_coord = x_coord;
+        this.y_coord = y_coord;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #26 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 변경
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) develop -> dev

## 📝작업 내용

> 공공데이터 OpenApi에서 서울시 음식점, 문화공간 데이터를 불러오도록 했습니다.

### 변경 사항
1. **json-simple** gradle을 추가했습니다.
2. 아직 DB가 제대로 구축되어 있지 않은 관계로, 서버 시작시 CommandLineRunner를 이용하여, openapi에서 데이터를 불러오도록 했습니다. 따라서 시간이 많이 소요되기 때문에, 데이터가 많은 음식점은 주석처리하고, **문화공간 데이터만 load하도록** 했습니다. **아직 Location이 DB에 저장되도록 하지 않았습니다!!!**

### 테스트 결과
서울시 문화공간 데이터가 모두 제대로 들어옵니다.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/502208e8-2fd2-4b37-a8c3-f2f24ea4ce10)

## 💬리뷰 요구사항(선택)

> AWS가 구축된 뒤에 음식점, 문화공간 데이터가 저장되도록 하겠습니다. (매번 서버 시작할 때마다 openapi에서 load해오면 시간이 많이 걸리기 때문입니다...) 다른 좋은 방법 있으면 말해주세요~