### PR TITLE
[fix] DateComment and Calendar

### DIFF
--- a/src/main/java/com/Lubee/Lubee/calendar/domain/Calendar.java
+++ b/src/main/java/com/Lubee/Lubee/calendar/domain/Calendar.java
@@ -4,6 +4,7 @@ import com.Lubee.Lubee.calendar_memory.domain.CalendarMemory;
 import com.Lubee.Lubee.common.BaseEntity;
 import com.Lubee.Lubee.couple.domain.Couple;
 import com.Lubee.Lubee.date_comment.domain.DateComment;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -29,6 +30,7 @@ public class Calendar extends BaseEntity {
     private Couple couple;
 
     @Temporal(TemporalType.DATE)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
     private Date eventDate;
 
     private String description;

--- a/src/main/java/com/Lubee/Lubee/date_comment/controller/DateCommentController.java
+++ b/src/main/java/com/Lubee/Lubee/date_comment/controller/DateCommentController.java
@@ -29,7 +29,7 @@ public class DateCommentController {
      * @return ApiResponseDto<Long>  생성된 Datecomment의 id를 포함
      */
     @PostMapping("")
-    public ApiResponseDto<Long> createDateComment(
+    public ApiResponseDto<SuccessResponse> createDateComment(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody final CreateDateCommentRequest createDateCommentRequest){
 
@@ -40,17 +40,15 @@ public class DateCommentController {
      * 커플의 데이트코멘트 조회 (날짜 하루)
      *
      * @param userDetails 인증된 사용자의 정보를 담고 있는 UserDetails 객체
-     * @param coupleId   커플 아이디
      * @param date   원하는 날짜
      * @return List<DateCommentResponse>
      */
     @GetMapping("/today")
     public ApiResponseDto<TodayDateCommentResponse> findTodayDateCommentByCouple(
             @AuthenticationPrincipal UserDetails userDetails,
-            @RequestParam Long coupleId,
             @RequestParam @DateTimeFormat(pattern = "yyyy.MM.dd") Date date){
 
-        return dateCommentService.findTodayDateCommentByCouple(userDetails, coupleId, date);
+        return dateCommentService.findTodayDateCommentByCouple(userDetails, date);
     }
 
     /**

--- a/src/main/java/com/Lubee/Lubee/date_comment/dto/CreateDateCommentRequest.java
+++ b/src/main/java/com/Lubee/Lubee/date_comment/dto/CreateDateCommentRequest.java
@@ -11,13 +11,12 @@ import java.util.Date;
 public class CreateDateCommentRequest {
 
     private String content;
-    private Long coupleId;
+
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
     private Date date;
 
-    public CreateDateCommentRequest(String content, Long coupleId, Date date) {
+    public CreateDateCommentRequest(String content, Date date) {
         this.content = content;
-        this.coupleId = coupleId;
         this.date = date;
     }
 }

--- a/src/main/java/com/Lubee/Lubee/date_comment/dto/UpdateDateCommentRequest.java
+++ b/src/main/java/com/Lubee/Lubee/date_comment/dto/UpdateDateCommentRequest.java
@@ -1,17 +1,21 @@
 package com.Lubee.Lubee.date_comment.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.Date;
 
 @Getter
 @NoArgsConstructor
 public class UpdateDateCommentRequest {
 
-    private Long datecommentId;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
+    private Date date;
     private String content;
 
-    public UpdateDateCommentRequest(Long datecommentId, String content) {
-        this.datecommentId = datecommentId;
+    public UpdateDateCommentRequest(Date date, String content) {
+        this.date = date;
         this.content = content;
     }
 }

--- a/src/main/java/com/Lubee/Lubee/date_comment/service/DateCommentService.java
+++ b/src/main/java/com/Lubee/Lubee/date_comment/service/DateCommentService.java
@@ -15,14 +15,17 @@ import com.Lubee.Lubee.date_comment.dto.*;
 import com.Lubee.Lubee.date_comment.repository.DateCommentRepository;
 import com.Lubee.Lubee.user.domain.User;
 import com.Lubee.Lubee.user.repository.UserRepository;
+import com.Lubee.Lubee.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -35,6 +38,7 @@ public class DateCommentService {
     private final DateCommentRepository dateCommentRepository;
     private final CoupleRepository coupleRepository;
     private final CalendarRepository calendarRepository;
+    private final UserService userService;
 
     /**
      * <데이트 코멘트 생성>
@@ -42,12 +46,10 @@ public class DateCommentService {
      *     - 데이트코멘트가 생성되면, Calendar에도 추가
      */
     @Transactional
-    public ApiResponseDto<Long> createDateComment(UserDetails userDetails, CreateDateCommentRequest createDateCommentRequest) {
+    public ApiResponseDto<SuccessResponse> createDateComment(UserDetails userDetails, CreateDateCommentRequest createDateCommentRequest) {
 
-        final User user = userRepository.findByUsername(userDetails.getUsername())
-                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
-        final Couple couple = coupleRepository.findById(createDateCommentRequest.getCoupleId())
-                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_COUPLE));
+        final User user = userService.getUser(userDetails);
+        final Couple couple = getUserCouple(user);
 
         // 캘린더가 없으면 해당 날짜의 캘린더를 생성
         Calendar calendar = calendarRepository.findByCoupleAndEventDate(couple, createDateCommentRequest.getDate());
@@ -75,7 +77,7 @@ public class DateCommentService {
         calendar.addDateComment(dateComment);    // 양방향 일대다 관계이기 때문
         dateCommentRepository.save(dateComment);
 
-        return ResponseUtils.ok(dateComment.getId(), ErrorResponse.builder().status(200).message("데이트코멘트 생성 성공").build());
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, "데이트코멘트 생성 완료"), ErrorResponse.builder().status(200).message("요청 성공").build());
     }
 
     /**
@@ -86,20 +88,18 @@ public class DateCommentService {
      *     - (3) 둘다 작성 o => 둘의 데이트코멘트 모두 반환
      */
     @Transactional(readOnly = true)
-    public ApiResponseDto<TodayDateCommentResponse> findTodayDateCommentByCouple(UserDetails userDetails, Long coupleId, Date date) {
+    public ApiResponseDto<TodayDateCommentResponse> findTodayDateCommentByCouple(UserDetails userDetails, Date date) {
 
-        final User user = userRepository.findByUsername(userDetails.getUsername())
-                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
+        final User user = userService.getUser(userDetails);
+        final Couple couple = getUserCouple(user);
 
-        final Couple couple = coupleRepository.findById(coupleId)
-                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_COUPLE));
-        if (!couple.getId().equals(coupleId)) {    // 커플id가 잘못됐을 때
-            throw new RestApiException(ErrorType.NOT_MATCHING_COUPLE);
-        }
 
         final Calendar calendar = calendarRepository.findByCoupleAndEventDate(couple, date);
         if (calendar == null) {               // 커플이 해당 달력을 만들지 않았으면..
-            throw new RestApiException(ErrorType.NOT_FOUND_CALENDAR);
+            return ResponseUtils.ok(
+                    null,
+                    ErrorResponse.builder().status(200).message("커플이 해당 날짜에 기록한 내용이 없습니다.").build()
+            );
         }
 
         TodayDateCommentResponse todayDateCommentResponses = new TodayDateCommentResponse();
@@ -110,7 +110,10 @@ public class DateCommentService {
         DateComment myComment = dateCommentRepository.findByUserAndCalendar(user, calendar);
 
         if (dateComments.isEmpty()) {     // 둘다 코멘트 작성x
-            throw new RestApiException(ErrorType.NOT_FOUND_COUPLE_DATE_COMMENT);
+            return ResponseUtils.ok(
+                    null,
+                    ErrorResponse.builder().status(200).message("커플 모두 데이트 코멘트를 작성하지 않았습니다.").build()
+            );
         }
 
         if (dateComments.size() == 1 && myComment != null) {    // 나만 작성
@@ -139,20 +142,20 @@ public class DateCommentService {
     @Transactional
     public SuccessResponse changeContent(UserDetails userDetails, UpdateDateCommentRequest updateDateCommentRequest) {
 
-        final User user = userRepository.findByUsername(userDetails.getUsername())
-                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_USER));
-        final DateComment dateComment = dateCommentRepository.findById(updateDateCommentRequest.getDatecommentId())
-                .orElseThrow(() -> new RestApiException(ErrorType.NOT_FOUND_DATE_COMMENT));
+        final User user = userService.getUser(userDetails);
+        final Couple couple = getUserCouple(user);
 
-        // 작성자와 현재 사용자를 비교하여 일치하지 않으면 예외 처리 - 작성자만 content를 바꿀 수 있음
-        if (!dateComment.getUser().equals(user)) {
-            throw new RestApiException(ErrorType.NOT_MATCHING_USER);
+        Optional<DateComment> dateComment = dateCommentRepository.findByUserAndCoupleAndCalendar_EventDate(user, couple, updateDateCommentRequest.getDate());
+        if(dateComment.isEmpty()) {
+            throw new RestApiException(ErrorType.NOT_FOUND_DATE_COMMENT);
+        }
+        else{
+            dateComment.get().changeContent(updateDateCommentRequest.getContent());
+            dateCommentRepository.save(dateComment.get());
+
+            return SuccessResponse.builder().status(200).message("데이트 코멘트 수정 성공").build();
         }
 
-        dateComment.changeContent(updateDateCommentRequest.getContent());
-        dateCommentRepository.save(dateComment);
-
-        return SuccessResponse.builder().status(200).message("데이트 코멘트 수정 성공").build();
     }
 
     /**
@@ -180,5 +183,17 @@ public class DateCommentService {
                         dateComment.getContent(),
                         dateComment.getUser().getProfile()))
                 .collect(Collectors.toList());
+    }
+
+    // 유저로 커플 찾는 함수
+    private Couple getUserCouple(User user) {
+        // Find the Couple associated with the User
+        Optional<Couple> optionalCouple = coupleRepository.findCoupleByUser(user);
+
+        if (optionalCouple.isEmpty()) {
+            throw new RestApiException(ErrorType.NOT_FOUND_COUPLE);
+        }
+
+        return optionalCouple.get();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 기능 변경
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) merging2 -> dev

## 📝작업 내용
> Calendar에서 date형식을 고정 "2024.07.23"이런식
> Datecomment API 변경 (datecomment의 id를 통신하지 않음)

### 변경 사항
**1. Calendar의 Date 형식**
2. datecomment의 api 통신 형식
